### PR TITLE
Updated deployment scripts to work on hardened ubuntu

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -95,8 +95,8 @@ echo "PORT=$PORT" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
 echo "EMAIL=$EMAIL" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
 echo "SECRET=$SECRET" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-sudo cp ~atsign/dess/$ATSIGN/.env ~atsign/base/
-sudo chmod 664 ~atsign/base/.env
+sudo cp /home/atsign/dess/$ATSIGN/.env /home/atsign/base/
+sudo chmod 664 /home/atsign/base/.env
 # Get the certificate for the @sign
     tput setaf 2
     echo "Getting certificates"
@@ -109,12 +109,12 @@ sudo certbot certonly --standalone --domains ${FQDN} --non-interactive --agree-t
 # Root CA
 sudo curl -L -o  ~atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem
 # Put some ownership in place so atsign can read the certs
-sudo chown -R atsign:atsign ~atsign/atsign/$ATSIGN
-sudo chown -R atsign:atsign ~atsign/atsign/etc/live/$FQDN
-sudo chown -R atsign:atsign ~atsign/atsign/etc/archive/$FQDN
-sudo chown -R atsign:atsign ~atsign/dess/$ATSIGN
+sudo chown -R atsign:atsign /home/atsign/atsign/$ATSIGN
+sudo chown -R atsign:atsign /home/atsign/atsign/etc/live/$FQDN
+sudo chown -R atsign:atsign /home/atsign/atsign/etc/archive/$FQDN
+sudo chown -R atsign:atsign /home/atsign/dess/$ATSIGN
 # Copy over restart script
-sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
+sudo cp base/restart.sh /home/atsign/atsign/etc/renewal-hooks/deploy
 #
 #
 # We are now ready to start the secondary !
@@ -124,8 +124,8 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # we use a neat trick usign docker-compose to create the compose file for us.
     echo Starting secondary for $ATSIGN at $FQDN on port $PORT as $DNAME on Docker
 
-sudo docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
-sudo docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
+sudo docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
+sudo docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
      echo Your QR-Code for $ATSIGN
      tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"

--- a/create.sh
+++ b/create.sh
@@ -87,13 +87,13 @@ sudo chown atsign:atsign ~atsign/dess/$ATSIGN/docker-swarm.yaml
 sudo -u atsign mkdir -p ~atsign/atsign/$ATSIGN/storage
 # Make the edits to the .env file
 # First comment out everything
-sudo -u atsign sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/$ATSIGN/.env
+sudo sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/$ATSIGN/.env
 # Add the environment variables we need
-echo "ATSIGN=$ATSIGN" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "DOMAIN=$FQDN" |sudo -u atsign tee -a ~atsign/dess/$ATSIGN/.env
-echo "PORT=$PORT" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "EMAIL=$EMAIL" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "SECRET=$SECRET" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
+echo "ATSIGN=$ATSIGN" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
+echo "DOMAIN=$FQDN" |sudo tee -a ~atsign/dess/$ATSIGN/.env
+echo "PORT=$PORT" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
+echo "EMAIL=$EMAIL" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
+echo "SECRET=$SECRET" |sudo tee -a  ~atsign/dess/$ATSIGN/.env
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
 sudo cp ~atsign/dess/$ATSIGN/.env ~atsign/base/
 sudo chmod 664 ~atsign/base/.env

--- a/create.sh
+++ b/create.sh
@@ -112,6 +112,7 @@ sudo curl -L -o  ~atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cac
 sudo chown -R atsign:atsign ~atsign/atsign/$ATSIGN
 sudo chown -R atsign:atsign ~atsign/atsign/etc/live/$FQDN
 sudo chown -R atsign:atsign ~atsign/atsign/etc/archive/$FQDN
+sudo chown -R atsign:atsign ~atsign/dess/$ATSIGN
 # Copy over restart script
 sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 #
@@ -122,6 +123,7 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
 # we use a neat trick usign docker-compose to create the compose file for us.
     echo Starting secondary for $ATSIGN at $FQDN on port $PORT as $DNAME on Docker
+
 sudo docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
 sudo docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
      echo Your QR-Code for $ATSIGN

--- a/create.sh
+++ b/create.sh
@@ -80,8 +80,9 @@ fi
 sudo mkdir -p ~atsign/dess/$ATSIGN
 sudo cp base/.env ~atsign/dess/$ATSIGN
 sudo cp base/docker-swarm.yaml ~atsign/dess/$ATSIGN
-chmod 664 ~atsign/dess/$ATSIGN/.env
-chmod 664 ~atsign/dess/$ATSIGN/docker-swarm.yaml
+sudo chmod 664 ~atsign/dess/$ATSIGN/.env
+sudo chown atsing:atsign ~atsign/dess/$ATSIGN/.env
+sudo chown atsign:atsign ~atsign/dess/$ATSIGN/docker-swarm.yaml
 # Make the directories in atsign
 sudo -u atsign mkdir -p ~atsign/atsign/$ATSIGN/storage
 # Make the edits to the .env file
@@ -94,7 +95,8 @@ echo "PORT=$PORT" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
 echo "EMAIL=$EMAIL" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
 echo "SECRET=$SECRET" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-sudo -u atsign cp  ~atsign/dess/$ATSIGN/.env ~atsign/base/
+sudo cp ~atsign/dess/$ATSIGN/.env ~atsign/base/
+sudo chmod 664 ~atsign/base/.env
 # Get the certificate for the @sign
     tput setaf 2
     echo "Getting certificates"

--- a/create.sh
+++ b/create.sh
@@ -122,8 +122,8 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
 # we use a neat trick usign docker-compose to create the compose file for us.
     echo Starting secondary for $ATSIGN at $FQDN on port $PORT as $DNAME on Docker
-sudo -u atsign docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
-sudo -u atsign docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
+sudo docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
+sudo docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
      echo Your QR-Code for $ATSIGN
      tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"

--- a/create.sh
+++ b/create.sh
@@ -77,9 +77,11 @@ fi
 
 
 # Copy files in from base
-sudo -u atsign mkdir -p ~atsign/dess/$ATSIGN
-sudo -u atsign cp  base/.env ~atsign/dess/$ATSIGN
-sudo -u atsign cp  base/docker-swarm.yaml ~atsign/dess/$ATSIGN
+sudo mkdir -p ~atsign/dess/$ATSIGN
+sudo cp base/.env ~atsign/dess/$ATSIGN
+sudo cp base/docker-swarm.yaml ~atsign/dess/$ATSIGN
+chmod 664 ~atsign/dess/$ATSIGN/.env
+chmod 664 ~atsign/dess/$ATSIGN/docker-swarm.yaml
 # Make the directories in atsign
 sudo -u atsign mkdir -p ~atsign/atsign/$ATSIGN/storage
 # Make the edits to the .env file

--- a/create.sh
+++ b/create.sh
@@ -81,7 +81,7 @@ sudo mkdir -p ~atsign/dess/$ATSIGN
 sudo cp base/.env ~atsign/dess/$ATSIGN
 sudo cp base/docker-swarm.yaml ~atsign/dess/$ATSIGN
 sudo chmod 664 ~atsign/dess/$ATSIGN/.env
-sudo chown atsing:atsign ~atsign/dess/$ATSIGN/.env
+sudo chown atsign:atsign ~atsign/dess/$ATSIGN/.env
 sudo chown atsign:atsign ~atsign/dess/$ATSIGN/docker-swarm.yaml
 # Make the directories in atsign
 sudo -u atsign mkdir -p ~atsign/atsign/$ATSIGN/storage
@@ -120,7 +120,7 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
     tput setaf 2
 # It would be nice to use the @sign for the name but
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
-# we use a neat trick using docker-compose to create the compose file for us.
+# we use a neat trick usign docker-compose to create the compose file for us.
     echo Starting secondary for $ATSIGN at $FQDN on port $PORT as $DNAME on Docker
 sudo -u atsign docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
 sudo -u atsign docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE

--- a/scripts/atsign.sh
+++ b/scripts/atsign.sh
@@ -29,6 +29,9 @@ sudo cp base/setup.sh ~atsign/base/
 sudo chmod 664 ~atsign/base/.env
 sudo chmod 664 ~atsign/base/docker-swarm.yaml
 sudo chmod 664 ~atsign/base/setup.sh
+sudo chown atsign:atsign ~atsign/base/.env
+sudo chown atsign:atsign ~atsign/base/docker-swarm.yaml
+sudo chown atsign:atsign ~atsign/base/setup.sh
 tput setaf 2
 echo "Setting up crontab to renew certs once a day"
 #sudo -u atsign crontab ~atsign/base/atsign_crontab

--- a/scripts/atsign.sh
+++ b/scripts/atsign.sh
@@ -23,9 +23,12 @@ sudo -u atsign mkdir -p ~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/ats
 tput setaf 2
 echo "Copying over the base config files"
 tput setaf 9
-sudo -u atsign cp base/.env ~atsign/base/
-sudo -u atsign cp base/docker-swarm.yaml ~atsign/base/
-sudo -u atsign cp base/setup.sh ~atsign/base/
+sudo cp base/.env ~atsign/base/
+sudo cp base/docker-swarm.yaml ~atsign/base/
+sudo cp base/setup.sh ~atsign/base/
+sudo chmod 664 ~atsign/base/.env
+sudo chmod 664 ~atsign/base/docker-swarm.yaml
+sudo chmod 664 ~atsign/base/setup.sh
 tput setaf 2
 echo "Setting up crontab to renew certs once a day"
 #sudo -u atsign crontab ~atsign/base/atsign_crontab


### PR DESCRIPTION
**- What I did**
I have updated install_software.sh, create.sh, atsign.sh to work correctly on hardened ubuntu in GCP cloud. Main change was explicate execution of permissions and ownership of dess files.
**- How I did it**
Change from execution under atsing user to root followed by reassigning of ownership of files and change of permissions.
**- How to verify it**
execute deployment on fresh machine
**- Description for the changelog**
Update of deployment scripts to support hardened OS.