### PR TITLE
Curl script one line installer and Debian, CentOS support.

### DIFF
--- a/Instructions.md
+++ b/Instructions.md
@@ -25,7 +25,7 @@
   ```
 - Install the software and follow the prompts to install the atsign user
   ```
-  curl -fsSL https://raw.githubusercontent.com/atsign-foundation/dess/trunk/getdess.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/atsign-foundation/dess/trunk/getdess.sh | sudo bash
   ```
 - Create a secondary, using the create.sh script and follow the instructions
   ```

--- a/Instructions.md
+++ b/Instructions.md
@@ -9,9 +9,8 @@
 - An @sign from atsign.com
 
 ### What is missing right now
-- We are working on the interface on atsign.com to enter your dns/port for your @sign, this is a blocker for the moment but you can install and test this environment in the meantime
-- The intent is to provide this environment for AMD64/ARM32/ARM64 CPU architectures but 0.0.1 supports only AMD64
-- We assume the machine we are installing on has no other software installed. SO carefully examine the scripts if for example you want to install a specific version of docker. Hints are in the scripts on how to do this
+- The intent is to provide this environment for AMD64/ARM32/ARM64 CPU architectures but 0.1.1 supports only AMD64/ARM64
+- We assume the machine we are installing on has no other software installed. So carefully examine the scripts if for example you want to install a specific version of docker. Hints are in the scripts on how to do this
 
 ## Getting started
 - Make sure you have root access via sudo for your account

--- a/Instructions.md
+++ b/Instructions.md
@@ -1,4 +1,4 @@
-# Instructions v0.0.1+1
+# Instructions v0.1.1+1
 
 ## Preparation
 ### You will need

--- a/Instructions.md
+++ b/Instructions.md
@@ -14,30 +14,26 @@
 - We assume the machine we are installing on has no other software installed. SO carefully examine the scripts if for example you want to install a specific version of docker. Hints are in the scripts on how to do this
 
 ## Getting started
-- Install this repo
-  ```
-  sudo apt update
-  sudo apt install git
-  cd
-  git clone https://github.com/atsign-foundation/dess.git
-  cd dess
-  ```
 - Make sure you have root access via sudo for your account
   ```
   sudo -s 
   # exit
   ```
+- Debian and Ubuntu users may need to install curl first:
+  ```
+  sudo apt install curl
+  ```
 - Install the software and follow the prompts to install the atsign user
   ```
-  ./install_software.sh
+  curl -fsSL https://raw.githubusercontent.com/atsign-foundation/dess/trunk/getdess.sh | bash
   ```
 - Create a secondary, using the create.sh script and follow the instructions
   ```
-  ./create.sh
+  dess-create
   ```
 - If you need to see the QR code again for an @sign then run:
   ```
-  ./reshowqr.sh @youratsign
+  dess-reshowqr @youratsign
   ```
 - Sign in to the atsign.com registrar and update your @signs DNS and port number information
 - Fire up an @ app like @buzz or @wavi and pair your device to your secondary

--- a/Instructions.md
+++ b/Instructions.md
@@ -5,8 +5,8 @@
 - Freshly built Linux machine (Ubuntu/Debian/CentOS)
 - A static or Dynamic DNS address that points the machines IP interface
 - A free port number that is accessible from the internet to your machine (1024-65535)
-- An email address so you can get the SSL Certificate from LetsEncrypt.com 
-- An @sign from atsign.com 
+- An email address so you can get the SSL Certificate from LetsEncrypt.com
+- An @sign from atsign.com
 
 ### What is missing right now
 - We are working on the interface on atsign.com to enter your dns/port for your @sign, this is a blocker for the moment but you can install and test this environment in the meantime
@@ -16,7 +16,7 @@
 ## Getting started
 - Make sure you have root access via sudo for your account
   ```
-  sudo -s 
+  sudo -s
   # exit
   ```
 - Debian and Ubuntu users may need to install curl first:

--- a/Instructions.md
+++ b/Instructions.md
@@ -2,7 +2,7 @@
 
 ## Preparation
 ### You will need
-- Freshly built Linux machine (Ubuntu/Debian)
+- Freshly built Linux machine (Ubuntu/Debian/CentOS)
 - A static or Dynamic DNS address that points the machines IP interface
 - A free port number that is accessible from the internet to your machine (1024-65535)
 - An email address so you can get the SSL Certificate from LetsEncrypt.com 

--- a/create.sh
+++ b/create.sh
@@ -77,28 +77,28 @@ fi
 
 
 # Copy files in from base
-sudo -u atsign mkdir -p ~atsign/dess/"$ATSIGN"
-sudo -u atsign cp  base/.env ~atsign/dess/"$ATSIGN"
-sudo -u atsign cp  base/docker-swarm.yaml ~atsign/dess/"$ATSIGN"
+runuser -l atsign -c mkdir -p ~atsign/dess/"$ATSIGN"
+runuser -l atsign -c cp  base/.env ~atsign/dess/"$ATSIGN"
+runuser -l atsign -c cp  base/docker-swarm.yaml ~atsign/dess/"$ATSIGN"
 # Make the directories in atsign
-sudo -u atsign mkdir -p ~atsign/atsign/"$ATSIGN"/storage
+runuser -l atsign -c mkdir -p ~atsign/atsign/"$ATSIGN"/storage
 # Make the edits to the .env file
 # First comment out everything
-sudo -u atsign sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/"$ATSIGN"/.env
+runuser -l atsign -c sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/"$ATSIGN"/.env
 # Add the environment variables we need
-echo "ATSIGN=$ATSIGN" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
-echo "DOMAIN=$FQDN" |sudo -u atsign tee -a ~atsign/dess/"$ATSIGN"/.env
-echo "PORT=$PORT" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
-echo "EMAIL=$EMAIL" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
-echo "SECRET=$SECRET" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "ATSIGN=$ATSIGN" |runuser -l atsign -c tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "DOMAIN=$FQDN" |runuser -l atsign -c tee -a ~atsign/dess/"$ATSIGN"/.env
+echo "PORT=$PORT" |runuser -l atsign -c tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "EMAIL=$EMAIL" |runuser -l atsign -c tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "SECRET=$SECRET" |runuser -l atsign -c tee -a  ~atsign/dess/"$ATSIGN"/.env
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-sudo -u atsign cp  ~atsign/dess/"$ATSIGN"/.env ~atsign/base/
+runuser -l atsign -c cp  ~atsign/dess/"$ATSIGN"/.env ~atsign/base/
 # Get the certificate for the @sign
     tput setaf 2
     echo "Getting certificates"
     tput setaf 9
 
-#     sudo -u atsign docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
+#     runuser -l atsign -c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
 sudo certbot certonly --standalone --domains "$FQDN" --non-interactive --agree-tos -m "$EMAIL"
 
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
@@ -118,8 +118,8 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
 # we use a neat trick using docker-compose to create the compose file for us.
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-sudo -u atsign docker-compose --env-file ~atsign/dess/"$ATSIGN"/.env -f ~atsign/dess/"$ATSIGN"/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
-sudo -u atsign docker stack deploy -c ~atsign/dess/"$ATSIGN"/docker-compose.yaml "$SERVICE"
+runuser -l atsign -c docker-compose --env-file ~atsign/dess/"$ATSIGN"/.env -f ~atsign/dess/"$ATSIGN"/docker-swarm.yaml config | runuser -l atsign -c tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
+runuser -l atsign -c docker stack deploy -c ~atsign/dess/"$ATSIGN"/docker-compose.yaml "$SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"

--- a/create.sh
+++ b/create.sh
@@ -18,7 +18,7 @@ export env SERVICE=$5
 
 # Let's make a secret whilst we are here !
 # hashalot should have been installed by now
-export env SECRET=`head -30 /dev/urandom |openssl -x sha512`
+export env SECRET=`head -30 /dev/urandom |openssl sha512`
 
 # Check that we have an @ in the @sign
 if [[ ! $ATSIGN  =~ ^@.*$ ]]

--- a/create.sh
+++ b/create.sh
@@ -122,7 +122,7 @@ change_sh 'root'
 $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 
 #     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
-$sh_c "/snap/bin/certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
+$sh_c "/usr/bin/certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
 
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
 # Root CA

--- a/create.sh
+++ b/create.sh
@@ -77,37 +77,37 @@ fi
 
 
 # Copy files in from base
-sudo -u atsign mkdir -p ~atsign/dess/$ATSIGN
-sudo -u atsign cp  base/.env ~atsign/dess/$ATSIGN
-sudo -u atsign cp  base/docker-swarm.yaml ~atsign/dess/$ATSIGN
+sudo -u atsign mkdir -p ~atsign/dess/"$ATSIGN"
+sudo -u atsign cp  base/.env ~atsign/dess/"$ATSIGN"
+sudo -u atsign cp  base/docker-swarm.yaml ~atsign/dess/"$ATSIGN"
 # Make the directories in atsign
-sudo -u atsign mkdir -p ~atsign/atsign/$ATSIGN/storage
+sudo -u atsign mkdir -p ~atsign/atsign/"$ATSIGN"/storage
 # Make the edits to the .env file
 # First comment out everything
-sudo -u atsign sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/$ATSIGN/.env
+sudo -u atsign sed -i 's/^\([^#].*\)/# \1/g' ~atsign/dess/"$ATSIGN"/.env
 # Add the environment variables we need
-echo "ATSIGN=$ATSIGN" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "DOMAIN=$FQDN" |sudo -u atsign tee -a ~atsign/dess/$ATSIGN/.env
-echo "PORT=$PORT" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "EMAIL=$EMAIL" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
-echo "SECRET=$SECRET" |sudo -u atsign tee -a  ~atsign/dess/$ATSIGN/.env
+echo "ATSIGN=$ATSIGN" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "DOMAIN=$FQDN" |sudo -u atsign tee -a ~atsign/dess/"$ATSIGN"/.env
+echo "PORT=$PORT" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "EMAIL=$EMAIL" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
+echo "SECRET=$SECRET" |sudo -u atsign tee -a  ~atsign/dess/"$ATSIGN"/.env
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-sudo -u atsign cp  ~atsign/dess/$ATSIGN/.env ~atsign/base/
+sudo -u atsign cp  ~atsign/dess/"$ATSIGN"/.env ~atsign/base/
 # Get the certificate for the @sign
     tput setaf 2
     echo "Getting certificates"
     tput setaf 9
 
 #     sudo -u atsign docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
-sudo certbot certonly --standalone --domains ${FQDN} --non-interactive --agree-tos -m ${EMAIL}
+sudo certbot certonly --standalone --domains "$FQDN" --non-interactive --agree-tos -m "$EMAIL"
 
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
 # Root CA
-sudo curl -L -o  ~atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem
+sudo curl -L -o  ~atsign/atsign/etc/live/"$FQDN"/cacert.pem https://curl.se/ca/cacert.pem
 # Put some ownership in place so atsign can read the certs
-sudo chown -R atsign:atsign ~atsign/atsign/$ATSIGN
-sudo chown -R atsign:atsign ~atsign/atsign/etc/live/$FQDN
-sudo chown -R atsign:atsign ~atsign/atsign/etc/archive/$FQDN
+sudo chown -R atsign:atsign ~atsign/atsign/"$ATSIGN"
+sudo chown -R atsign:atsign ~atsign/atsign/etc/live/"$FQDN"
+sudo chown -R atsign:atsign ~atsign/atsign/etc/archive/"$FQDN"
 # Copy over restart script
 sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 #
@@ -117,10 +117,10 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # It would be nice to use the @sign for the name but
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
 # we use a neat trick using docker-compose to create the compose file for us.
-    echo Starting secondary for $ATSIGN at $FQDN on port $PORT as $DNAME on Docker
-sudo -u atsign docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
-sudo -u atsign docker stack deploy -c ~atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE
-     echo Your QR-Code for $ATSIGN
-     tput setaf 9
+    echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
+sudo -u atsign docker-compose --env-file ~atsign/dess/"$ATSIGN"/.env -f ~atsign/dess/"$ATSIGN"/docker-swarm.yaml config | sudo -u atsign tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null
+sudo -u atsign docker stack deploy -c ~atsign/dess/"$ATSIGN"/docker-compose.yaml "$SERVICE"
+    echo Your QR-Code for "$ATSIGN"
+    tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"
 

--- a/create.sh
+++ b/create.sh
@@ -93,14 +93,16 @@ tput setaf 2
 echo "Creating $ATSIGN with $FQDN:$PORT with email $EMAIL with docker service name of $SERVICE"
 tput setaf 9
 
+change_sh 'root'
+# Make the directories in atsign
+$sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
+
 change_sh 'atsign'
 
 # Copy files in from base
 $sh_c "mkdir -p /home/atsign/dess/$ATSIGN"
 $sh_c "cp /home/atsign/base/.env /home/atsign/dess/$ATSIGN"
 $sh_c "cp /home/atsign/base/docker-swarm.yaml /home/atsign/dess/$ATSIGN"
-# Make the directories in atsign
-$sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # Make the edits to the .env file
 # First comment out everything
 $sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"

--- a/create.sh
+++ b/create.sh
@@ -14,7 +14,7 @@ export env SERVICE=$5
 
 # Let's make a secret whilst we are here !
 # hashalot should have been installed by now
-export env SECRET=`head -30 /dev/urandom |openssl sha512`
+export env SECRET=$(head -30 /dev/urandom |openssl sha512)
 
 # Check that we have an @ in the @sign
 if [[ ! $ATSIGN  =~ ^@.*$ ]]

--- a/create.sh
+++ b/create.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -eq 0 || $# -gt 5 ]] ; then
-    echo 'Usage create.sh <@sign> <fqdn> <port> <email> <service>'
-    echo "Example create.sh @bob bob.example.com 6464 bob@example.com bob"
+    echo 'Usage dess-create <@sign> <fqdn> <port> <email> <service>'
+    echo "Example dess-create @bob bob.example.com 6464 bob@example.com bob"
     exit 0
 fi
 

--- a/create.sh
+++ b/create.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -eq 0 || $# -gt 5 ]] ; then
-    echo 'Usage dess-create <@sign> <fqdn> <port> <email> <service>'
-    echo "Example dess-create @bob bob.example.com 6464 bob@example.com bob"
+    echo 'Usage sudo dess-create <@sign> <fqdn> <port> <email> <service>'
+    echo "Example sudo dess-create @bob bob.example.com 6464 bob@example.com bob"
     exit 0
 fi
 

--- a/create.sh
+++ b/create.sh
@@ -93,9 +93,6 @@ tput setaf 2
 echo "Creating $ATSIGN with $FQDN:$PORT with email $EMAIL with docker service name of $SERVICE"
 tput setaf 9
 
-change_sh 'root'
-# Make the directories in atsign
-$sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 
 change_sh 'atsign'
 
@@ -120,6 +117,9 @@ echo "Getting certificates"
 tput setaf 9
 
 change_sh 'root'
+
+# Make the directories in atsign
+$sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 
 #     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
 $sh_c "certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"

--- a/create.sh
+++ b/create.sh
@@ -71,6 +71,10 @@ then
     exit 1
 fi
 
+command_exists () {
+    command -v "$@" > /dev/null 2>&1
+}
+
 sh_c=''
 change_sh () {
     if command_exists sudo; then

--- a/create.sh
+++ b/create.sh
@@ -103,7 +103,7 @@ $sh_c "cp /home/atsign/base/docker-swarm.yaml /home/atsign/dess/$ATSIGN"
 $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # Make the edits to the .env file
 # First comment out everything
-#$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
+$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
 # Add the environment variables we need
 $sh_c "echo ATSIGN=$ATSIGN | tee -a /home/atsign/dess/$ATSIGN/.env"
 $sh_c "echo DOMAIN=$FQDN | tee -a /home/atsign/dess/$ATSIGN/.env"
@@ -126,7 +126,7 @@ $sh_c "certbot certonly --standalone --domains $FQDN --non-interactive --agree-t
 # Root CA
 $sh_c "curl -L -o  /home/atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem"
 # Put some ownership in place so atsign can read the certs
-$sh_c "chown -R atsign:atsign /home/atsign/dess/$ATSIGN"
+$sh_c "chown -R atsign:atsign /home/atsign/atsign/$ATSIGN"
 $sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/live/$FQDN"
 $sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/archive/$FQDN"
 # Copy over restart script

--- a/create.sh
+++ b/create.sh
@@ -146,7 +146,7 @@ $sh_c "cp /home/atsign/base/restart.sh /home/atsign/atsign/etc/renewal-hooks/dep
 # we use a neat trick using docker-compose to create the compose file for us.
 change_sh 'atsign'
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-$sh_c "export TMPDIR=$HOME/tmp; /usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null;"
+$sh_c "export TMPDIR=/home/atsign/tmp; /usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null;"
 $sh_c "/usr/bin/docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9

--- a/create.sh
+++ b/create.sh
@@ -123,7 +123,11 @@ $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 
 #     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
 $sh_c "/usr/bin/certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
-
+CERTBOT_RESULT=$?
+if [[ $CERTBOT_RESULT -gt 0 ]]
+    echo 'Error: certbot failed to get a certificate.'
+    exit 1
+fi
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
 # Root CA
 $sh_c "curl -L -o  /home/atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem"

--- a/create.sh
+++ b/create.sh
@@ -14,7 +14,7 @@ export env SERVICE=$5
 
 # Let's make a secret whilst we are here !
 # hashalot should have been installed by now
-export env SECRET=$(head -30 /dev/urandom |openssl sha512)
+export env SECRET=$(head -30 /dev/urandom |openssl sha512 | awk -F'= ' '{print $2}')
 
 # Check that we have an @ in the @sign
 if [[ ! $ATSIGN  =~ ^@.*$ ]]
@@ -105,11 +105,11 @@ $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # First comment out everything
 #$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
 # Add the environment variables we need
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo ATSIGN="$ATSIGN" | awk -F= '{print $1 $2}')"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo DOMAIN="$FQDN" | awk -F= '{print $1 $2}')"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo PORT="$PORT" | awk -F= '{print $1 $2}')"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo EMAIL="$EMAIL" | awk -F= '{print $1 $2}')"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo SECRET="$SECRET" | awk -F= '{print $1 $2}')"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< ATSIGN=$ATSIGN"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< DOMAIN=$FQDN"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< PORT=$PORT"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< EMAIL=$EMAIL"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< SECRET=$SECRET"
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
 $sh_c "cp /home/atsign/dess/$ATSIGN/.env /home/atsign/base/"
 # Get the certificate for the @sign

--- a/create.sh
+++ b/create.sh
@@ -146,7 +146,7 @@ $sh_c "cp /home/atsign/base/restart.sh /home/atsign/atsign/etc/renewal-hooks/dep
 # we use a neat trick using docker-compose to create the compose file for us.
 change_sh 'atsign'
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-$sh_c "/usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
+$sh_c "export TMPDIR=$HOME/tmp; /usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null;"
 $sh_c "/usr/bin/docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9

--- a/create.sh
+++ b/create.sh
@@ -78,9 +78,9 @@ command_exists () {
 sh_c=''
 change_sh () {
     if command_exists sudo; then
-        sh_c="sudo -E -u $1 sh -c"
+        sh_c="sudo -u $1 sh -c"
     elif command_exists su; then
-        sh_c="su -l $1 --preserve-environment -c"
+        sh_c="su -l $1 -c"
     else
         echo 'Error: unable to perform operations as atsign user';
         exit 1
@@ -103,15 +103,15 @@ $sh_c "cp /home/atsign/base/docker-swarm.yaml /home/atsign/dess/$ATSIGN"
 $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # Make the edits to the .env file
 # First comment out everything
-$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
+#$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
 # Add the environment variables we need
-$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< ATSIGN=$ATSIGN"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< DOMAIN=$FQDN"
-$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< PORT=$PORT"
-$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< EMAIL=$EMAIL"
-$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< SECRET=$SECRET"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo ATSIGN="$ATSIGN" | awk -F= '{print $1 $2}')"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo DOMAIN="$FQDN" | awk -F= '{print $1 $2}')"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo PORT="$PORT" | awk -F= '{print $1 $2}')"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo EMAIL="$EMAIL" | awk -F= '{print $1 $2}')"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< $(echo SECRET="$SECRET" | awk -F= '{print $1 $2}')"
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-$sh_c "cp  /home/atsign/dess/$ATSIGN/.env /home/atsign/base/"
+$sh_c "cp /home/atsign/dess/$ATSIGN/.env /home/atsign/base/"
 # Get the certificate for the @sign
 tput setaf 2
 echo "Getting certificates"

--- a/create.sh
+++ b/create.sh
@@ -14,7 +14,7 @@ export env SERVICE=$5
 
 # Let's make a secret whilst we are here !
 # hashalot should have been installed by now
-export env SECRET=$(head -30 /dev/urandom |openssl sha512 | awk -F'= ' '{print $2}')
+export env SECRET=$(head -30 /dev/urandom | openssl sha512 | awk -F'= ' '{print $2}')
 
 # Check that we have an @ in the @sign
 if [[ ! $ATSIGN  =~ ^@.*$ ]]
@@ -126,11 +126,11 @@ $sh_c "certbot certonly --standalone --domains $FQDN --non-interactive --agree-t
 # Root CA
 $sh_c "curl -L -o  /home/atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem"
 # Put some ownership in place so atsign can read the certs
-$sh_c "chown -R atsign:atsign /home/atsign/atsign/$ATSIGN"
+$sh_c "chown -R atsign:atsign /home/atsign/dess/$ATSIGN"
 $sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/live/$FQDN"
 $sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/archive/$FQDN"
 # Copy over restart script
-$sh_c "cp base/restart.sh /home/atsign/atsign/etc/renewal-hooks/deploy"
+$sh_c "cp /home/atsign/base/restart.sh /home/atsign/atsign/etc/renewal-hooks/deploy"
 #
 #
 # We are now ready to start the secondary !
@@ -140,8 +140,8 @@ $sh_c "cp base/restart.sh /home/atsign/atsign/etc/renewal-hooks/deploy"
 # we use a neat trick using docker-compose to create the compose file for us.
 change_sh 'atsign'
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-$sh_c "docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
-$sh_c "docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
+$sh_c "/usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
+$sh_c "/usr/bin/docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"

--- a/create.sh
+++ b/create.sh
@@ -124,7 +124,7 @@ $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 #     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
 $sh_c "/usr/bin/certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
 CERTBOT_RESULT=$?
-if [[ $CERTBOT_RESULT -gt 0 ]]
+if [[ $CERTBOT_RESULT -gt 0 ]]; then
     echo 'Error: certbot failed to get a certificate.'
     exit 1
 fi

--- a/create.sh
+++ b/create.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ $EUID != 0 ]; then
-    echo 'Error: please run this script as root.'
-fi
-
 if [[ $# -eq 0 || $# -gt 5 ]] ; then
     echo 'Usage create.sh <@sign> <fqdn> <port> <email> <service>'
     echo "Example create.sh @bob bob.example.com 6464 bob@example.com bob"
@@ -75,46 +71,62 @@ then
     exit 1
 fi
 
-# Confirm arguments look valid
-    tput setaf 2
-    echo "Creating $ATSIGN with $FQDN:$PORT with email $EMAIL with docker service name of $SERVICE"
-    tput setaf 9
+sh_c=''
+change_sh () {
+    if command_exists sudo; then
+        sh_c="sudo -E -u $1 sh -c"
+    elif command_exists su; then
+        sh_c="su -l $1 --preserve-environment -c"
+    else
+        echo 'Error: unable to perform operations as atsign user';
+        exit 1
+    fi
+}
 
+
+# Confirm arguments look valid
+tput setaf 2
+echo "Creating $ATSIGN with $FQDN:$PORT with email $EMAIL with docker service name of $SERVICE"
+tput setaf 9
+
+change_sh 'atsign'
 
 # Copy files in from base
-runuser -l atsign -c "mkdir -p /home/atsign/dess/$ATSIGN"
-runuser -l atsign -c "cp /home/atsign/base/.env /home/atsign/dess/$ATSIGN"
-runuser -l atsign -c "cp /home/atsign/base/docker-swarm.yaml /home/atsign/dess/$ATSIGN"
+$sh_c "mkdir -p /home/atsign/dess/$ATSIGN"
+$sh_c "cp /home/atsign/base/.env /home/atsign/dess/$ATSIGN"
+$sh_c "cp /home/atsign/base/docker-swarm.yaml /home/atsign/dess/$ATSIGN"
 # Make the directories in atsign
-runuser -l atsign -c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
+$sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # Make the edits to the .env file
 # First comment out everything
-runuser -l atsign -c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
+$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
 # Add the environment variables we need
-echo "ATSIGN=$ATSIGN" |runuser -l atsign -c "tee -a  /home/atsign/dess/$ATSIGN/.env"
-echo "DOMAIN=$FQDN" |runuser -l atsign -c "tee -a /home/atsign/dess/$ATSIGN/.env"
-echo "PORT=$PORT" |runuser -l atsign -c "tee -a  /home/atsign/dess/$ATSIGN/.env"
-echo "EMAIL=$EMAIL" |runuser -l atsign -c "tee -a  /home/atsign/dess/$ATSIGN/.env"
-echo "SECRET=$SECRET" |runuser -l atsign -c "tee -a  /home/atsign/dess/$ATSIGN/.env"
+$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< ATSIGN=$ATSIGN"
+$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< DOMAIN=$FQDN"
+$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< PORT=$PORT"
+$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< EMAIL=$EMAIL"
+$sh_c "tee -a  /home/atsign/dess/$ATSIGN/.env <<< SECRET=$SECRET"
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
-runuser -l atsign -c cp  ~atsign/dess/"$ATSIGN"/.env ~atsign/base/
+$sh_c "cp  /home/atsign/dess/$ATSIGN/.env /home/atsign/base/"
 # Get the certificate for the @sign
-    tput setaf 2
-    echo "Getting certificates"
-    tput setaf 9
+tput setaf 2
+echo "Getting certificates"
+tput setaf 9
 
-#     runuser -l atsign -c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
-sudo certbot certonly --standalone --domains "$FQDN" --non-interactive --agree-tos -m "$EMAIL"
+change_sh 'root'
+
+#     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
+$sh_c "certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
 
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
 # Root CA
-sudo curl -L -o  /home/atsign/atsign/etc/live/"$FQDN"/cacert.pem https://curl.se/ca/cacert.pem
+$sh_c "curl -L -o  /home/atsign/atsign/etc/live/$FQDN/cacert.pem https://curl.se/ca/cacert.pem"
 # Put some ownership in place so atsign can read the certs
-sudo chown -R atsign:atsign "/home/atsign/atsign/$ATSIGN"
-sudo chown -R atsign:atsign "/home/atsign/atsign/etc/live/$FQDN"
-sudo chown -R atsign:atsign "/home/atsign/atsign/etc/archive/$FQDN"
+$sh_c "chown -R atsign:atsign /home/atsign/atsign/$ATSIGN"
+$sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/live/$FQDN"
+$sh_c "chown -R atsign:atsign /home/atsign/atsign/etc/archive/$FQDN"
 # Copy over restart script
-sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
+$sh_c "cp base/restart.sh /home/atsign/atsign/etc/renewal-hooks/deploy"
 #
 #
 # We are now ready to start the secondary !
@@ -122,9 +134,10 @@ sudo cp base/restart.sh ~atsign/atsign/etc/renewal-hooks/deploy
 # It would be nice to use the @sign for the name but
 # Docker insists on a name that is DNS compliant and so emojis and @ signs are out hence the $SERVICE tag
 # we use a neat trick using docker-compose to create the compose file for us.
+change_sh 'atsign'
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-runuser -l atsign -c "docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
-runuser -l atsign -c "docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
+$sh_c "docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
+$sh_c "docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9
 qrencode -t ANSIUTF8 "${ATSIGN}:${SECRET}"

--- a/create.sh
+++ b/create.sh
@@ -13,7 +13,7 @@ export env SERVICE=$5
 
 # Let's make a secret whilst we are here !
 # hashalot should have been installed by now
-export env SECRET=`head -30 /dev/urandom |hashalot -x sha512`
+export env SECRET=`head -30 /dev/urandom |openssl -x sha512`
 
 # Check that we have an @ in the @sign
 if [[ ! $ATSIGN  =~ ^@.*$ ]]

--- a/create.sh
+++ b/create.sh
@@ -122,7 +122,7 @@ change_sh 'root'
 $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 
 #     $sh_c docker-compose --env-file ~atsign/dess/$ATSIGN/.env -f ~atsign/dess/$ATSIGN/docker-compose.yaml run  --service-ports cert
-$sh_c "certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
+$sh_c "/snap/bin/certbot certonly --standalone --domains $FQDN --non-interactive --agree-tos -m $EMAIL"
 
 # Last task to put in place the restart script and regenerate the ssl root CA file (as root)
 # Root CA

--- a/create.sh
+++ b/create.sh
@@ -105,11 +105,11 @@ $sh_c "mkdir -p /home/atsign/atsign/$ATSIGN/storage"
 # First comment out everything
 #$sh_c "sed -i 's/^\([^#].*\)/# \1/g' /home/atsign/dess/$ATSIGN/.env"
 # Add the environment variables we need
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< ATSIGN=$ATSIGN"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< DOMAIN=$FQDN"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< PORT=$PORT"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< EMAIL=$EMAIL"
-$sh_c "tee -a /home/atsign/dess/$ATSIGN/.env <<< SECRET=$SECRET"
+$sh_c "echo ATSIGN=$ATSIGN | tee -a /home/atsign/dess/$ATSIGN/.env"
+$sh_c "echo DOMAIN=$FQDN | tee -a /home/atsign/dess/$ATSIGN/.env"
+$sh_c "echo PORT=$PORT | tee -a /home/atsign/dess/$ATSIGN/.env"
+$sh_c "echo EMAIL=$EMAIL | tee -a /home/atsign/dess/$ATSIGN/.env"
+$sh_c "echo SECRET=$SECRET | tee -a /home/atsign/dess/$ATSIGN/.env"
 # copy over the .env file to base so we can renew the certs with an up to date EMAIL
 $sh_c "cp /home/atsign/dess/$ATSIGN/.env /home/atsign/base/"
 # Get the certificate for the @sign
@@ -140,7 +140,7 @@ $sh_c "cp /home/atsign/base/restart.sh /home/atsign/atsign/etc/renewal-hooks/dep
 # we use a neat trick using docker-compose to create the compose file for us.
 change_sh 'atsign'
     echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
-$sh_c "/usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee ~atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
+$sh_c "/usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null"
 $sh_c "/usr/bin/docker stack deploy -c /home/atsign/dess/$ATSIGN/docker-compose.yaml $SERVICE"
     echo Your QR-Code for "$ATSIGN"
     tput setaf 9

--- a/getdess.sh
+++ b/getdess.sh
@@ -141,7 +141,7 @@ install_docker () {
       aarch64|arm64) 
         case "$os_release" in
           amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;;
-          ubuntu|debian) $pkg_man install -y python3-pip;;
+          *) $pkg_man install -y python3 python3-pip;;
         esac;
         pip3 install docker-compose;
       ;;

--- a/getdess.sh
+++ b/getdess.sh
@@ -24,7 +24,7 @@ lxc_packages="fuse squashfuse"
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/1.29/docker-compose-$(uname -s)-$(uname -m)"
+compose_url="https://github.com/docker/compose/releases/download/1.29/docker-compose"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"
@@ -123,7 +123,7 @@ install_docker () {
   fi
 
   # docker-compose
-  curl -fsSL "$compose_url" -o /usr/local/bin/docker-compose
+  curl -fsSL "$compose_url-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 }
@@ -185,7 +185,7 @@ setup_docker () {
   # setup and deploy the swarm as atsign
   docker swarm init
   docker network create -d overlay secondaries
-  docker stack deploy -c base/shepherd.yaml secondaries
+  docker stack deploy -c ~atsign/base/shepherd.yaml secondaries
 }
 
 test_atsign_user () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -61,6 +61,8 @@ pre_install () {
   echo "Detected package manager: $pkg_man"
 }
 
+# Functions below are run as root via do_install
+
 install_dependencies () {
   # openssl, qrencode, curl
   # if container

--- a/getdess.sh
+++ b/getdess.sh
@@ -102,12 +102,15 @@ install_certbot () {
   ln -s /var/lib/snapd/snap /snap
   # enable and start snapd
   systemctl enable --now snapd.service
+  systemctl start snapd.service
   # wait for snapd to startup
   STATUS=1
   while [[ $STATUS -ne 0 ]]; do
     systemctl is-active --quiet snapd.service
     STATUS=$?
   done
+  echo Starting snapd service
+  sleep 2
   # install snap core
   snap install core
   snap refresh core

--- a/getdess.sh
+++ b/getdess.sh
@@ -265,6 +265,11 @@ get_dess_scripts () {
   done
 }
 
+post_install() {
+  echo;
+  echo 'Dess installed, please move on to the dess-create command.'
+}
+
 do_install () {
   pre_install
 
@@ -281,6 +286,8 @@ do_install () {
   setup_docker
   test_atsign_user
   get_dess_scripts
+  
+  post_install
 }
 
 do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -137,6 +137,7 @@ install_docker () {
       echo 'Failed to install docker-compose, trying another installation method...'
       sudo curl -fsSL "$compose_url/run.sh" -o /usr/local/bin/docker-compose
       COMPOSE_RESULT_2=$?
+      echo "$COMPOSE_RESULT_2"
       if [[ $COMPOSE_RESULT_2 -gt 0 ]]; then
         echo 'Error: unable to install docker compose'
         exit 51

--- a/getdess.sh
+++ b/getdess.sh
@@ -26,6 +26,15 @@ packages="curl openssl qrencode"
 # Docker compose link
 compose_url="https://github.com/docker/compose/releases/download/1.29/docker-compose-$(uname -s)-$(uname -m)"
 
+# Atsign user info
+user_info="atsign, secondaries account, atsign.com"
+
+# Atsign directories
+atsign_dirs="~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/atsign/etc ~atsign/atsign/logs"
+
+# Repository files
+repo_url=""
+atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
 
 command_exists () {
   command -v "$@" > /dev/null 2>&1
@@ -202,6 +211,11 @@ do_install () {
     os_release=$os_release
     pkg_man=$pkg_man
     compose_url=$compose_url
+    user_info=$user_info
+    atsign_dirs=$atsign_dirs
+    repo_url=$repo_url
+    atsign_files=$atsign_files
+    original_user=$USER
     $FUNC;
     install_dependencies
     install_certbot

--- a/getdess.sh
+++ b/getdess.sh
@@ -154,6 +154,7 @@ install_docker () {
       exit 51
     fi
   fi
+  chown root:docker /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
   systemctl enable --now docker.service
@@ -162,13 +163,13 @@ install_docker () {
 mkdir_atsign () {
   mkdir -p "$1"
   echo "making $1"
-  chown atsign "$1"
+  chown atsign:atsign "$1"
 }
 
 curl_atsign_file () {
   curl -fsSL "$repo_url/$1" -o "/home/atsign/$1"
   echo "curling $1"
-  chown atsign "/home/atsign/$1"
+  chown atsign:atsign "/home/atsign/$1"
 }
 
 setup_atsign_user () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -64,9 +64,16 @@ pre_install () {
 # Functions below are run as root via do_install
 
 install_dependencies () {
-  # openssl, qrencode, curl
-  # if container
-  # install fuse squashfuse
+  $pkg_man -y update
+  for pkg in $packages; do
+    $pkg_man -y install $pkg
+  done
+  # Container support
+  if [[ $(systemd-detect-virt) -ne 'none' ]]; then
+    for lxc_pkg in $lxc_packages; do
+      $pkg_man -y install $lxc_pkg
+    done
+  fi
 }
 
 install_certbot () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -110,14 +110,7 @@ install_certbot () {
     rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$($os_id | awk -F. '{print $1}').noarch.rpm";;
     *);;
   esac
-  # Versions using this approach
-  # Ubuntu 20.10 - 1.7.0
-  # Debian 10 - 0.31.0
-  # Fedora 34 - 1.14.0
-  # Centos 7 - 1.11.0
-  # Centos 8 - 1.14.0
-  # Amazon Linux - 1.11.0
-  # RHEL 8 - 1.14.0
+
   echo y | $pkg_man -y install certbot
   CERTBOT_RESULT=$?
   if [[ $CERTBOT_RESULT -gt 0 ]]; then

--- a/getdess.sh
+++ b/getdess.sh
@@ -33,7 +33,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/atsign/etc ~atsign/atsign/logs"
 
 # Repository files
-repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing/getdess.sh"
+repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
 dess_scripts="create reshowqr"
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -91,10 +91,11 @@ install_dependencies () {
   for pkg in $packages; do
     if ! command_exists "$pkg"; then
       $pkg_man -y install "$pkg"
-    fi
-    if ! command_exists "pkg"; then
-      echo "Error: unable to install package $pkg"
-      exit 3
+      PKG_RESULT=$?
+      if [[ $PKG_RESULT -gt 0 ]]; then
+        echo "Error: unable to install package $pkg"
+        exit 3
+      fi
     fi
   done
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -255,15 +255,9 @@ do_install () {
 
   sh_c=''
   if [[ $EUID -ne 0 ]]; then
-    if command_exists sudo; then
-      sh_c='sudo -E sh -c'
-    elif command_exists su; then
-      sh_c='su --preserve-environment -c'
-    else
-      echo 'Error: unable to perform root operations';
-      echo 'Please run this script as root to complete installation.';
-      exit 1
-    fi
+    echo 'Error: unable to perform root operations';
+    echo 'Please run this script as root to complete installation.';
+    exit 1
   fi
 
   $sh_c install_dependencies

--- a/getdess.sh
+++ b/getdess.sh
@@ -135,6 +135,7 @@ install_docker () {
   if ! command_exists docker-compose; then
     # Try the x86_64 installer first
     curl -fsSL "$compose_url-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    echo 'Failed to install docker-compose, trying another installation method...'
     COMPOSE_RESULT=$?
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then

--- a/getdess.sh
+++ b/getdess.sh
@@ -198,15 +198,8 @@ setup_docker () {
 }
 
 test_atsign_user () {
-  # run as user command
-  sh_uc=''
-  if command_exists sudo; then
-    sh_uc='sudo -u atsign sh -c'
-  elif command_exists su; then
-    sh_uc='su atsign -c'
-  fi
   # check if docker works for atsign user
-  "$sh_uc" /usr/bin/docker run hello-world
+  runuser -l atsign -c /usr/bin/docker run hello-world
   RESULT=$?
   if [[ $RESULT -eq 0 ]]; then
     echo "Docker setup correctly for atsign user"

--- a/getdess.sh
+++ b/getdess.sh
@@ -66,8 +66,10 @@ pre_install () {
       echo 'Error: Could not detect your distribution.'
       exit 2
   fi
-  echo "Detected release id: $os_release, version: $os_id";
-
+  
+  echo "Detected release id: $os_release, version: $os_id"
+  echo "Detected architecture: $(uname -m)"
+  
   if ! is_release "$arch_support" "$(uname -m)"; then
     echo "Your architecture ($(uname -m)) is currently unsupported by this script."
     exit 0

--- a/getdess.sh
+++ b/getdess.sh
@@ -13,9 +13,27 @@ set -m
 # Container Dependencies
 # fuse squashfuse
 
+# SCRIPT GLOBALS
 
-preinstall () {
-  # get user's release
+# Supported distros by type
+debian_releases='ubuntu debian'
+redhat_releases='centos fedora'
+
+# Required base packages
+lxc_packages="fuse squashfuse"
+packages="curl openssl qrencode"
+
+
+
+command_exists () {
+  command -v "$@" > /dev/null 2>&1
+}
+
+# Helper function to check if user's release matches the list
+# $1 = list of valid releases
+# $2 = release to check
+is_release () { [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]]; }
+
   # get package manager
   # update package repos
 }
@@ -76,7 +94,7 @@ do_install () {
   fi
 
   FUNC=$(declare -f)
-  $sh_c '
+  $sh_c "
     $FUNC;
     install_dependencies
     install_certbot
@@ -85,7 +103,7 @@ do_install () {
     setup_docker
     test_atsign_user
     get_dess_scripts
-  ';
+  ";
 }
 
 do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -29,7 +29,7 @@ redhat_releases='centos fedora amzn rhel'
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/1.29.2"
+compose_url="https://github.com/docker/compose/releases/download/1.29.1"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"

--- a/getdess.sh
+++ b/getdess.sh
@@ -81,7 +81,7 @@ install_dependencies () {
     $pkg_man -y install $pkg
   done
   # Container support
-  if [[ $(systemd-detect-virt) -ne 'none' ]]; then
+  if [[ $(systemd-detect-virt) != 'none' ]]; then
     for lxc_pkg in $lxc_packages; do
       $pkg_man -y install $lxc_pkg
     done
@@ -92,7 +92,7 @@ install_certbot () {
   # install snapd
   if [[ "$os_release" == centos ]]; then
     $pkg_man -y install epel-release
-  elif [[ "os_release" == fedora ]]; then
+  elif [[ "$os_release" == fedora ]]; then
     $pkg_man -y install kernel-modules
   fi
   $pkg_man -y install snapd
@@ -191,7 +191,7 @@ test_atsign_user () {
     sh_uc='su atsign --preserve-environment -c'
   fi
   # check if docker works for atsign user
-  sh_uc docker run hello-world
+  "$sh_uc" docker run hello-world
   RESULT=$?
   if [[ $RESULT -eq 0 ]]; then
     echo "Docker setup correctly for atsign user"

--- a/getdess.sh
+++ b/getdess.sh
@@ -207,6 +207,7 @@ setup_atsign_user () {
   done
 
   chown atsign:atsign /home/atsign
+  
 }
 
 setup_docker () {
@@ -260,7 +261,7 @@ get_dess_scripts () {
       echo "Error: failed to install dess-$script"
       exit 6
     fi
-    chmod +x /usr/local/bin/dess-"$script"
+    chmod 774 /usr/local/bin/dess-"$script"
     ln -s /usr/local/bin/dess-"$script" /usr/bin/dess-"$script"
   done
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -35,6 +35,7 @@ atsign_dirs="~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/atsign/etc ~at
 # Repository files
 repo_url=""
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
+dess_scripts="create reshowqr"
 
 command_exists () {
   command -v "$@" > /dev/null 2>&1
@@ -203,6 +204,11 @@ test_atsign_user () {
 get_dess_scripts () {
   # curl create and reshowqr from repo
   # to /usr/local/bin
+  for script in $dess_scripts; do
+    curl -fsSL "$repo_url"/"$script".sh /usr/local/bin/dess-"$script"
+    chmod +x /usr/local/bin/dess-"$script"
+    ln -s /usr/local/bin/dess-"$script" /usr/bin/dess-"$script"
+  done
 }
 
 do_install () {
@@ -213,7 +219,7 @@ do_install () {
     if command_exists sudo; then
       sh_c='sudo -E sh -c'
     elif command_exists su; then
-      sh_c='su -c'
+      sh_c='su --preserve-environment -c'
     else
       echo 'Error: unable to perform root operations';
       echo 'Please run this script as root to complete installation.';

--- a/getdess.sh
+++ b/getdess.sh
@@ -198,7 +198,7 @@ test_atsign_user () {
     sh_uc='su atsign -c'
   fi
   # check if docker works for atsign user
-  "$sh_uc" docker run hello-world
+  "$sh_uc" /usr/bin/docker run hello-world
   RESULT=$?
   if [[ $RESULT -eq 0 ]]; then
     echo "Docker setup correctly for atsign user"

--- a/getdess.sh
+++ b/getdess.sh
@@ -87,7 +87,7 @@ install_dependencies () {
 install_certbot () {
   case "$os_release" in
     centos) echo y | $pkg_man -y install epel-release;;
-
+    amazon) echo y | amazon-linux-extras install epel;;
     *);;
   esac
   # Versions using this approach
@@ -96,6 +96,7 @@ install_certbot () {
   # Fedora 34 - 1.14.0
   # Centos 7 - 1.11.0
   # Centos 8 - 1.14.0
+  # Amazon Linux - 1.11.0
   echo y | $pkg_man -y install certbot
 }
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Enable job control
+set -m
+
+# Dess installation
+
+# Dependencies
+# openssl, qrencode
+# docker, docker-compose, snapd
+# certbot (via snap)
+
+# Container Dependencies
+# fuse squashfuse

--- a/getdess.sh
+++ b/getdess.sh
@@ -6,7 +6,7 @@ set -m
 # Dess installation
 
 # Dependencies
-# openssl, qrencode
+# openssl, qrencode, curl
 # docker, docker-compose, snapd
 # certbot (via snap)
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -107,8 +107,10 @@ install_certbot () {
 install_docker () {
   # docker
   if ! command_exists docker; then
-    curl -fsSL https://get.docker.com -o get-docker.sh
-    sh get-docker.sh
+    case $os_release in
+      amzn) amazon-linux-extras install docker;;
+      *) curl -fsSL https://get.docker.com | sh;;
+    esac
   fi
 
   # docker-compose

--- a/getdess.sh
+++ b/getdess.sh
@@ -51,7 +51,7 @@ is_release () { [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]]; }
 pre_install () {
   # Get the user's release
   os_release=$(awk -F= '/^ID/{print $2}' /etc/os-release | sed 's/\"//g')
-  os_id=$(awk -F= '/^VERSION_ID/{print $2' /etc/os-release | sed 's/\"//g')
+  os_id=$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | sed 's/\"//g')
 
   if [ -z "$os_release" ]
   then

--- a/getdess.sh
+++ b/getdess.sh
@@ -101,7 +101,16 @@ install_certbot () {
 }
 
 install_docker () {
-  # docker, docker compose
+  # docker
+  if ! command_exists docker; then
+    curl -fsSL https://get.docker.com -o get-docker.sh
+    sh get-docker.sh
+  fi
+
+  # docker-compose
+  curl -fsSL "$compose_url" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 }
 
 setup_atsign_user () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -139,8 +139,8 @@ install_docker () {
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then
       sudo curl -fsSL https://github.com/docker/compose/releases/download/1.29.2/run.sh -o /usr/local/bin/docker-compose
-      COMPOSE_RESULT=$?
-      if [[ $COMPOSE_RESULT -gt 0 ]]; then
+      COMPOSE_RESULT_2=$?
+      if [[ $COMPOSE_RESULT_2 -gt 0 ]]; then
         echo 'Error: unable to install docker compose'
         exit 51
       fi

--- a/getdess.sh
+++ b/getdess.sh
@@ -91,7 +91,7 @@ install_dependencies () {
 install_certbot () {
   case "$os_release" in
     centos) echo y | $pkg_man -y install epel-release;;
-    amazon) echo y | amazon-linux-extras install epel;;
+    amzn) echo y | amazon-linux-extras install epel;;
     rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$($os_id | awk -F. '{print $1}').noarch.rpm";;
     *);;
   esac

--- a/getdess.sh
+++ b/getdess.sh
@@ -40,7 +40,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
 
 # Repository files
-repo_url="https://raw.githubusercontent.com/xavierchanth/dess/certbot-install-testing"
+repo_url="https://raw.githubusercontent.com/xavierchanth/dess/curl-testing"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml base/restart.sh"
 dess_scripts="create reshowqr"
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -34,7 +34,7 @@ atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/a
 
 # Repository files
 repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing"
-atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
+atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml base/restart.sh"
 dess_scripts="create reshowqr"
 
 # Original user

--- a/getdess.sh
+++ b/getdess.sh
@@ -33,7 +33,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/atsign/etc ~atsign/atsign/logs"
 
 # Repository files
-repo_url=""
+repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing/getdess.sh"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
 dess_scripts="create reshowqr"
 
@@ -217,8 +217,35 @@ get_dess_scripts () {
   done
 }
 
+functions="
+  command_exists
+  pre_install
+  install_dependencies
+  install_certbot
+  install_docker
+  mkdir_atsign
+  curl_atsign_file
+  setup_atsign_user
+  setup_docker
+  test_atsign_user
+  get_dess_scripts
+  "
+
+export_functions () {
+  for func in $functions; do
+    export -f "${func?}"
+  done
+}
+
+unset_functions () {
+  for func in $functions; do
+    unset "$func"
+  done
+}
+
 do_install () {
   pre_install
+  export_functions
 
   sh_c=''
   if [[ $EUID -ne 0 ]]; then
@@ -233,7 +260,6 @@ do_install () {
     fi
   fi
 
-  FUNC=$(declare -f)
   $sh_c "
     install_dependencies
     install_certbot
@@ -243,6 +269,8 @@ do_install () {
     test_atsign_user
     get_dess_scripts
   ";
+
+  unset_functions
 }
 
 do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -132,8 +132,7 @@ install_docker () {
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
       *) case "$os_release" in
-          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;
-                sudo pip3 install docker-compose;;
+          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel; sudo pip3 install docker-compose;;
     esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"

--- a/getdess.sh
+++ b/getdess.sh
@@ -115,15 +115,54 @@ install_docker () {
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 }
 
+mkdir_atsign () {
+  mkdir -p "$1"
+  chown atsign "$1"
+}
+
+curl_atsign_file () {
+  curl -fsSL "$repo_url"/"$1" ~atsign/"$1"
+  chown atsign ~atsign/"$1"
+}
+
 setup_atsign_user () {
   # add atsign user
+  if [[ $pkg_man == apt-get ]]; then
+    adduser -uid 1024 --disabled-password --disabled-login --gecos "$user_info" atsign
+  else
+    adduser --uid 1024 --comment "$user_info" atsign
+  fi
+
   # link lets-encrypt folder
+  if [[ ! -d ~atsign/atsign/etc ]]; then
+    tput setaf 2
+    echo "setting up certbot"
+    rm /etc/letsencrypt/*
+    rmdir /etc/letsencrypt/
+    ln -s ~atsign/atsign/etc /etc/letsencrypt
+    tput setaf 9
+  else
+    tput setaf 1
+    echo 'saved you from destroying letsencrypt by running the script again :-)'
+    tput setaf 9
+  fi
+
   # make ~atsign directories
+  tput setaf 2
+  echo "Creating some base directories for atsign"
+  tput setaf 9
+  for directory in $atsign_dirs; do
+    mkdir_atsign "$directory"
+  done
+  tput setaf 2
+
   # curl the base files for atsign
+  for file in $atsign_files; do
+    curl_atsign_file "$file"
+  done
 }
 
 setup_docker () {
-  # curl the base/shepherd.yaml file to atsign
   # give atsign user docker permissions
   # setup and deploy the swarm as atsign
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -182,7 +182,22 @@ setup_docker () {
 }
 
 test_atsign_user () {
+  # run as user command
+  sh_uc=''
+  if command_exists sudo; then
+    sh_uc='sudo -u atsign -E sh -c'
+  elif command_exists su; then
+    sh_uc='su atsign --preserve-environment -c'
+  fi
   # check if docker works for atsign user
+  sh_uc docker run hello-world
+  RESULT=$?
+  if [[ $RESULT -eq 0 ]]; then
+    echo "Docker setup correctly for atsign user"
+  else
+    echo "Please check docker install, something went wrong"
+    exit 1
+  fi
 }
 
 get_dess_scripts () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -97,6 +97,12 @@ install_certbot () {
 
     *);;
   esac
+  # Versions using this approach
+  # Ubuntu 20.10 - 1.7.0
+  # Debian 10 - 0.31.0
+  # Fedora 34 - 1.14.0
+  # Centos 7 - 1.11.0
+  # Centos 8 - 1.14.0
   echo y | $pkg_man -y install certbot
 }
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -78,9 +78,26 @@ install_dependencies () {
 
 install_certbot () {
   # install snapd
+  if [[ "$os_release" == centos ]]; then
+    $pkg_man -y install epel-release
+  elif [[ "os_release" == fedora ]]; then
+    $pkg_man -y install kernel-modules
+  fi
+  $pkg_man -y install snapd
+  ln -s /var/lib/snapd/snap /snap
+  # enable and start snapd
+  systemctl enable --now snapd.service
+  # wait for snapd to startup
+  STATUS=1
+  while [[ $STATUS -ne 0 ]]; do
+    systemctl is-active --quiet snapd.service
+    RESULT=$?
+  done
   # install snap core
-  # enable and link snap
+  snap install core
+  snap refresh core
   # install certbot
+  snap install --classic certbot
 }
 
 install_docker () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -106,7 +106,7 @@ install_certbot () {
   STATUS=1
   while [[ $STATUS -ne 0 ]]; do
     systemctl is-active --quiet snapd.service
-    RESULT=$?
+    STATUS=$?
   done
   # install snap core
   snap install core

--- a/getdess.sh
+++ b/getdess.sh
@@ -235,17 +235,6 @@ do_install () {
 
   FUNC=$(declare -f)
   $sh_c "
-    # Just in case the environment isn't preserved correctly
-    os_release=$os_release
-    pkg_man=$pkg_man
-    compose_url=$compose_url
-    user_info=$user_info
-    atsign_dirs=$atsign_dirs
-    repo_url=$repo_url
-    atsign_files=$atsign_files
-    dess_scripts=$dess_scripts
-    original_user=$original_user
-    $FUNC;
     install_dependencies
     install_certbot
     install_docker

--- a/getdess.sh
+++ b/getdess.sh
@@ -149,12 +149,12 @@ setup_atsign_user () {
   fi
 
   # link lets-encrypt folder
-  if [[ ! -d ~atsign/atsign/etc ]]; then
+  if [[ ! -d /home/atsign/atsign/etc ]]; then
     tput setaf 2
     echo "setting up certbot"
     rm /etc/letsencrypt/*
     rmdir /etc/letsencrypt/
-    ln -s ~atsign/atsign/etc /etc/letsencrypt
+    ln -s /home/atsign/atsign/etc /etc/letsencrypt
     tput setaf 9
   else
     tput setaf 1

--- a/getdess.sh
+++ b/getdess.sh
@@ -194,9 +194,9 @@ test_atsign_user () {
   # run as user command
   sh_uc=''
   if command_exists sudo; then
-    sh_uc='sudo -u atsign -E sh -c'
+    sh_uc='sudo -u atsign sh -c'
   elif command_exists su; then
-    sh_uc='su atsign --preserve-environment -c'
+    sh_uc='su atsign -c'
   fi
   # check if docker works for atsign user
   "$sh_uc" docker run hello-world
@@ -205,7 +205,6 @@ test_atsign_user () {
     echo "Docker setup correctly for atsign user"
   else
     echo "Please check docker install, something went wrong"
-    exit 1
   fi
 }
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -139,9 +139,8 @@ install_docker () {
     echo "$COMPOSE_RESULT"
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then
-        echo 'Error: unable to install docker compose'
-        exit 51
-      fi
+      echo 'Error: unable to install docker compose'
+      exit 51
     fi
   fi
   chmod +x /usr/local/bin/docker-compose

--- a/getdess.sh
+++ b/getdess.sh
@@ -17,7 +17,7 @@ set -m
 
 # Supported distros by type
 debian_releases='ubuntu debian'
-redhat_releases='centos fedora'
+redhat_releases='centos fedora amazon'
 
 # Required base packages
 lxc_packages="fuse squashfuse"

--- a/getdess.sh
+++ b/getdess.sh
@@ -260,15 +260,13 @@ do_install () {
     fi
   fi
 
-  $sh_c "
-    install_dependencies
-    install_certbot
-    install_docker
-    setup_atsign_user
-    setup_docker
-    test_atsign_user
-    get_dess_scripts
-  ";
+  $sh_c install_dependencies
+  $sh_c install_certbot
+  $sh_c install_docker
+  $sh_c setup_atsign_user
+  $sh_c setup_docker
+  $sh_c test_atsign_user
+  $sh_c get_dess_scripts
 
   unset_functions
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -24,7 +24,7 @@ lxc_packages="fuse squashfuse"
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/1.29/docker-compose"
+compose_url="https://github.com/docker/compose/releases/download/1.29.2/docker-compose"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"

--- a/getdess.sh
+++ b/getdess.sh
@@ -31,7 +31,7 @@ arch_support='x86_64 amd64 aarch64 arm64'
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/latest"
+compose_url="https://github.com/docker/compose/releases/download/1.29.2"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"

--- a/getdess.sh
+++ b/getdess.sh
@@ -25,6 +25,8 @@ set -m
 debian_releases='ubuntu debian'
 redhat_releases='centos fedora amzn rhel'
 
+arch_support='x86_64 amd64 aarch64 arm64'
+
 # Required base packages
 packages="curl openssl qrencode"
 
@@ -66,6 +68,11 @@ pre_install () {
   fi
   echo "Detected release id: $os_release, version: $os_id";
 
+  if ! is_release "$arch_support" "$(uname -m)"; then
+    echo "Your architecture ($(uname -m)) is currently unsupported by this script."
+    exit 0
+  fi
+
   # get package manager
   if is_release "$debian_releases" "$os_release"; then
     pkg_man='apt-get'
@@ -77,7 +84,7 @@ pre_install () {
       pkg_man='yum'
     fi
   else
-    echo 'Your distribution is currently not supported by this script.'
+    echo 'Your distribution is currently unsupported by this script.'
     exit 0
   fi
   echo "Detected package manager: $pkg_man"
@@ -131,7 +138,7 @@ install_docker () {
     # Try the x86_64 installer first
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
-      *) case "$os_release" in
+      aarch64|arm64) case "$os_release" in
           amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;
                 sudo pip3 install docker-compose;;
         esac;;

--- a/getdess.sh
+++ b/getdess.sh
@@ -37,7 +37,7 @@ compose_url="https://github.com/docker/compose/releases/download/1.29.2"
 user_info="atsign, secondaries account, atsign.com"
 
 # Atsign directories
-atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
+atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs /home/atsign/tmp"
 
 # Repository files
 repo_url="https://raw.githubusercontent.com/xavierchanth/dess/curl-testing"

--- a/getdess.sh
+++ b/getdess.sh
@@ -29,7 +29,7 @@ redhat_releases='centos fedora amzn rhel'
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/1.29.1"
+compose_url="https://github.com/docker/compose/releases/download/latest"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"
@@ -121,7 +121,7 @@ install_docker () {
   # docker
   if ! command_exists docker; then
     case $os_release in
-      amzn) amazon-linux-extras install docker;;
+      amzn) amazon-linux-extras install docker docker-compose;;
       *) curl -fsSL https://get.docker.com | sh;;
     esac
   fi
@@ -131,7 +131,9 @@ install_docker () {
     # Try the x86_64 installer first
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
-      *) $pkg_man -y install docker-compose;;
+      *) case "$os_release" in
+          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;
+                sudo pip3 install docker-compose;;
     esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"

--- a/getdess.sh
+++ b/getdess.sh
@@ -23,7 +23,7 @@ set -m
 
 # Supported distros by type
 debian_releases='ubuntu debian'
-redhat_releases='centos fedora amzn rhel'
+redhat_releases='centos fedora amzn rhel rocky'
 
 arch_support='x86_64 amd64 aarch64 arm64'
 
@@ -58,8 +58,8 @@ is_release () { [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]]; }
 
 pre_install () {
   # Get the user's release
-  os_release=$(awk -F= '/^ID=/{print $2}' /etc/os-release | sed 's/\"//g')
-  os_id=$(awk -F= '/^VERSION_ID=/{print $2}' /etc/os-release | sed 's/\"//g')
+  os_release=$(. /etc/os-release; echo $ID)
+  os_id=$(. /etc/os-release; echo $VERSION_ID)
 
   if [ -z "$os_release" ]
   then

--- a/getdess.sh
+++ b/getdess.sh
@@ -126,6 +126,7 @@ install_docker () {
   curl -fsSL "$compose_url-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  systemctl enable --now docker.service
 }
 
 mkdir_atsign () {
@@ -177,6 +178,13 @@ setup_atsign_user () {
 }
 
 setup_docker () {
+  # wait for docker to startup
+  STATUS=1
+  while [[ $STATUS -ne 0 ]]; do
+    systemctl is-active --quiet docker.service
+    STATUS=$?
+  done
+
   # give atsign user docker permissions
   usermod -aG docker atsign
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -81,12 +81,12 @@ pre_install () {
 install_dependencies () {
   $pkg_man -y update
   for pkg in $packages; do
-    $pkg_man -y install $pkg
+    $pkg_man -y install "$pkg"
   done
   # Container support
   if [[ $(systemd-detect-virt) != 'none' ]]; then
     for lxc_pkg in $lxc_packages; do
-      $pkg_man -y install $lxc_pkg
+      $pkg_man -y install "$lxc_pkg"
     done
   fi
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -82,7 +82,9 @@ pre_install () {
 install_dependencies () {
   $pkg_man -y update
   for pkg in $packages; do
-    $pkg_man -y install "$pkg"
+    if ! command_exists "$pkg"; then
+      $pkg_man -y install "$pkg"
+    fi
   done
 }
 
@@ -90,7 +92,7 @@ install_certbot () {
   case "$os_release" in
     centos) echo y | $pkg_man -y install epel-release;;
     amazon) echo y | amazon-linux-extras install epel;;
-    rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_id.noarch.rpm";;
+    rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$($os_id | awk -F. '{print $1}').noarch.rpm";;
     *);;
   esac
   # Versions using this approach

--- a/getdess.sh
+++ b/getdess.sh
@@ -17,7 +17,7 @@ set -m
 
 # Supported distros by type
 debian_releases='ubuntu debian'
-redhat_releases='centos fedora amazon'
+redhat_releases='centos fedora amzn rhel'
 
 # Required base packages
 packages="curl openssl qrencode"
@@ -32,7 +32,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
 
 # Repository files
-repo_url="https://raw.githubusercontent.com/xavierchanth/dess/curl-testing"
+repo_url="https://raw.githubusercontent.com/xavierchanth/dess/certbot-install-testing"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml base/restart.sh"
 dess_scripts="create reshowqr"
 
@@ -50,13 +50,15 @@ is_release () { [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]]; }
 
 pre_install () {
   # Get the user's release
-  os_release=$(awk -F= '/^NAME/{print $2}' /etc/os-release | sed 's/\"//g' | awk '{print tolower($1)}')
+  os_release=$(awk -F= '/^ID/{print $2}' /etc/os-release | sed 's/\"//g')
+  os_id=$(awk -F= '/^VERSION_ID/{print $2' /etc/os-release | sed 's/\"//g')
+
   if [ -z "$os_release" ]
   then
       echo 'Error: Could not detect your distribution.'
       exit 1
   fi
-  echo "Detected distribution: $os_release";
+  echo "Detected release id: $os_release, version: $os_id";
 
   # get package manager
   if is_release "$debian_releases" "$os_release"; then
@@ -88,6 +90,7 @@ install_certbot () {
   case "$os_release" in
     centos) echo y | $pkg_man -y install epel-release;;
     amazon) echo y | amazon-linux-extras install epel;;
+    rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_id.noarch.rpm";;
     *);;
   esac
   # Versions using this approach
@@ -97,6 +100,7 @@ install_certbot () {
   # Centos 7 - 1.11.0
   # Centos 8 - 1.14.0
   # Amazon Linux - 1.11.0
+  # RHEL 8 - 1.14.0
   echo y | $pkg_man -y install certbot
 }
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -180,6 +180,7 @@ setup_docker () {
     systemctl is-active --quiet docker.service
     STATUS=$?
     SECONDS=$SECONDS+1
+    sleep 1
     if [[ $SECONDS -gt 120 ]]; then
       echo 'Error: Docker daemon is not starting...'
       echo 'Please check your docker installation before running again.'

--- a/getdess.sh
+++ b/getdess.sh
@@ -23,6 +23,8 @@ redhat_releases='centos fedora'
 lxc_packages="fuse squashfuse"
 packages="curl openssl qrencode"
 
+# Docker compose link
+compose_url="https://github.com/docker/compose/releases/download/1.29/docker-compose-$(uname -s)-$(uname -m)"
 
 
 command_exists () {
@@ -155,6 +157,7 @@ do_install () {
   $sh_c "
     os_release=$os_release
     pkg_man=$pkg_man
+    compose_url=$compose_url
     $FUNC;
     install_dependencies
     install_certbot

--- a/getdess.sh
+++ b/getdess.sh
@@ -55,7 +55,7 @@ pre_install () {
   if [ -z "$os_release" ]
   then
       echo 'Error: Could not detect your distribution.'
-      exit 0
+      exit 1
   fi
   echo "Detected distribution: $os_release";
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -129,16 +129,14 @@ install_docker () {
   # docker-compose
   if ! command_exists docker-compose; then
     # Try the x86_64 installer first
-    curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    case $(uname -m) in
+      x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
+      *) $pkg_man -y install docker-compose;;
+    esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then
-      echo 'Failed to install docker-compose, trying another installation method...'
-      sudo curl -fsSL "$compose_url/run.sh" -o /usr/local/bin/docker-compose
-      COMPOSE_RESULT_2=$?
-      echo "$COMPOSE_RESULT_2"
-      if [[ $COMPOSE_RESULT_2 -gt 0 ]]; then
         echo 'Error: unable to install docker compose'
         exit 51
       fi

--- a/getdess.sh
+++ b/getdess.sh
@@ -132,10 +132,10 @@ install_docker () {
     case $os_release in
       amzn) amazon-linux-extras install docker;;
       rocky)
-        sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo;
-        sudo dnf -y update;
-        sudo dnf install docker-ce docker-ce-cli containerd.io;
-        sudo systemctl enable --now docker.service;
+        dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo;
+        dnf -y update;
+        dnf -y install docker-ce docker-ce-cli containerd.io;
+        systemctl enable --now docker.service;
       ;;
       *) curl -fsSL https://get.docker.com | sh;;
     esac

--- a/getdess.sh
+++ b/getdess.sh
@@ -20,7 +20,6 @@ debian_releases='ubuntu debian'
 redhat_releases='centos fedora amazon'
 
 # Required base packages
-lxc_packages="fuse squashfuse"
 packages="curl openssl qrencode"
 
 # Docker compose link
@@ -83,12 +82,6 @@ install_dependencies () {
   for pkg in $packages; do
     $pkg_man -y install "$pkg"
   done
-  # Container support
-  if [[ $(systemd-detect-virt) != 'none' ]]; then
-    for lxc_pkg in $lxc_packages; do
-      $pkg_man -y install "$lxc_pkg"
-    done
-  fi
 }
 
 install_certbot () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -164,7 +164,12 @@ setup_atsign_user () {
 
 setup_docker () {
   # give atsign user docker permissions
+  usermod -aG docker atsign
+
   # setup and deploy the swarm as atsign
+  docker swarm init
+  docker network create -d overlay secondaries
+  docker stack deploy -c base/shepherd.yaml secondaries
 }
 
 test_atsign_user () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -142,7 +142,7 @@ install_docker () {
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
       aarch64|arm64) case "$os_release" in
           amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;;
-                
+          ubuntu|debian) $pkg_man install -y python3-pip;;
         esac;
         pip3 install docker-compose;;
     esac

--- a/getdess.sh
+++ b/getdess.sh
@@ -253,20 +253,19 @@ do_install () {
   pre_install
   export_functions
 
-  sh_c=''
   if [[ $EUID -ne 0 ]]; then
     echo 'Error: unable to perform root operations';
     echo 'Please run this script as root to complete installation.';
     exit 1
   fi
 
-  $sh_c install_dependencies
-  $sh_c install_certbot
-  $sh_c install_docker
-  $sh_c setup_atsign_user
-  $sh_c setup_docker
-  $sh_c test_atsign_user
-  $sh_c get_dess_scripts
+  install_dependencies
+  install_certbot
+  install_docker
+  setup_atsign_user
+  setup_docker
+  test_atsign_user
+  get_dess_scripts
 
   unset_functions
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -33,7 +33,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
 
 # Repository files
-repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing"
+repo_url="https://raw.githubusercontent.com/atsign-foundation/dess/trunk"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml base/restart.sh"
 dess_scripts="create reshowqr"
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -130,10 +130,11 @@ install_docker () {
   if ! command_exists docker-compose; then
     # Try the x86_64 installer first
     curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    echo 'Failed to install docker-compose, trying another installation method...'
     COMPOSE_RESULT=$?
+    echo "$COMPOSE_RESULT"
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then
+      echo 'Failed to install docker-compose, trying another installation method...'
       sudo curl -fsSL "$compose_url/run.sh" -o /usr/local/bin/docker-compose
       COMPOSE_RESULT_2=$?
       if [[ $COMPOSE_RESULT_2 -gt 0 ]]; then

--- a/getdess.sh
+++ b/getdess.sh
@@ -30,7 +30,7 @@ redhat_releases='centos fedora amzn rhel'
 packages="curl openssl qrencode"
 
 # Docker compose link
-compose_url="https://github.com/docker/compose/releases/download/1.29.2/docker-compose"
+compose_url="https://github.com/docker/compose/releases/download/1.29.2"
 
 # Atsign user info
 user_info="atsign, secondaries account, atsign.com"
@@ -134,12 +134,12 @@ install_docker () {
   # docker-compose
   if ! command_exists docker-compose; then
     # Try the x86_64 installer first
-    curl -fsSL "$compose_url-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     echo 'Failed to install docker-compose, trying another installation method...'
     COMPOSE_RESULT=$?
     # Try the containerized installer
     if [[ $COMPOSE_RESULT -gt 0 ]]; then
-      sudo curl -fsSL https://github.com/docker/compose/releases/download/1.29.2/run.sh -o /usr/local/bin/docker-compose
+      sudo curl -fsSL "$compose_url/run.sh" -o /usr/local/bin/docker-compose
       COMPOSE_RESULT_2=$?
       if [[ $COMPOSE_RESULT_2 -gt 0 ]]; then
         echo 'Error: unable to install docker compose'

--- a/getdess.sh
+++ b/getdess.sh
@@ -50,8 +50,8 @@ is_release () { [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]]; }
 
 pre_install () {
   # Get the user's release
-  os_release=$(awk -F= '/^ID/{print $2}' /etc/os-release | sed 's/\"//g')
-  os_id=$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | sed 's/\"//g')
+  os_release=$(awk -F= '/^ID=/{print $2}' /etc/os-release | sed 's/\"//g')
+  os_id=$(awk -F= '/^VERSION_ID=/{print $2}' /etc/os-release | sed 's/\"//g')
 
   if [ -z "$os_release" ]
   then

--- a/getdess.sh
+++ b/getdess.sh
@@ -117,6 +117,7 @@ install_docker () {
 
   # docker-compose
   curl -fsSL "$compose_url-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  echo "TEST $?"
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
   systemctl enable --now docker.service

--- a/getdess.sh
+++ b/getdess.sh
@@ -132,7 +132,9 @@ install_docker () {
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
       *) case "$os_release" in
-          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel; sudo pip3 install docker-compose;;
+          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;
+                sudo pip3 install docker-compose;;
+        esac;;
     esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"

--- a/getdess.sh
+++ b/getdess.sh
@@ -13,7 +13,6 @@ set -m
 # Error Codes
 # 1  - Not running with root priveleges
 # 2  - Could not detect /etc/os-release ID
-# 3  - A dependency failed to install
 # 4  - certbot failed to install
 # 50 - docker daemon did not start ( in time )
 # 51 - docker-compose failed to install
@@ -91,11 +90,6 @@ install_dependencies () {
   for pkg in $packages; do
     if ! command_exists "$pkg"; then
       $pkg_man -y install "$pkg"
-      PKG_RESULT=$?
-      if [[ $PKG_RESULT -gt 0 ]]; then
-        echo "Error: unable to install package $pkg"
-        exit 3
-      fi
     fi
   done
 }

--- a/getdess.sh
+++ b/getdess.sh
@@ -229,6 +229,7 @@ do_install () {
 
   FUNC=$(declare -f)
   $sh_c "
+    # Just in case the environment isn't preserved correctly
     os_release=$os_release
     pkg_man=$pkg_man
     compose_url=$compose_url
@@ -236,6 +237,7 @@ do_install () {
     atsign_dirs=$atsign_dirs
     repo_url=$repo_url
     atsign_files=$atsign_files
+    dess_scripts=$dess_scripts
     original_user=$USER
     $FUNC;
     install_dependencies

--- a/getdess.sh
+++ b/getdess.sh
@@ -130,11 +130,13 @@ install_docker () {
 
 mkdir_atsign () {
   mkdir -p "$1"
+  echo "making $1"
   chown atsign "$1"
 }
 
 curl_atsign_file () {
   curl -fsSL "$repo_url"/"$1" -o ~atsign/"$1"
+  echo "curling $1"
   chown atsign ~atsign/"$1"
 }
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -175,6 +175,8 @@ setup_atsign_user () {
   for file in $atsign_files; do
     curl_atsign_file "$file"
   done
+
+  chown atsign:atsign /home/atsign
 }
 
 setup_docker () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -130,21 +130,28 @@ install_docker () {
   # docker
   if ! command_exists docker; then
     case $os_release in
-      amzn) amazon-linux-extras install docker docker-compose;;
+      amzn) amazon-linux-extras install docker;;
+      rocky)
+        sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo;
+        sudo dnf -y update;
+        sudo dnf install docker-ce docker-ce-cli containerd.io;
+        sudo systemctl enable --now docker.service;
+      ;;
       *) curl -fsSL https://get.docker.com | sh;;
     esac
   fi
 
   # docker-compose
   if ! command_exists docker-compose; then
-    # Try the x86_64 installer first
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
-      aarch64|arm64) case "$os_release" in
+      aarch64|arm64) 
+        case "$os_release" in
           amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;;
           ubuntu|debian) $pkg_man install -y python3-pip;;
         esac;
-        pip3 install docker-compose;;
+        pip3 install docker-compose;
+      ;;
     esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"

--- a/getdess.sh
+++ b/getdess.sh
@@ -94,6 +94,7 @@ install_dependencies () {
 install_certbot () {
   case "$os_release" in
     centos) echo y | $pkg_man -y install epel-release;;
+
     *);;
   esac
   echo y | $pkg_man -y install certbot
@@ -165,10 +166,17 @@ setup_atsign_user () {
 
 setup_docker () {
   # wait for docker to startup
+  SECONDS=0
   STATUS=1
-  while [[ $STATUS -ne 0 ]]; do
+  until [[ $STATUS -ne 0 ]]; do
     systemctl is-active --quiet docker.service
     STATUS=$?
+    SECONDS=$SECONDS+1
+    if [[ $SECONDS -gt 120 ]]; then
+      echo 'Error: Docker daemon is not starting...'
+      echo 'Please check your docker installation before running again.'
+      exit 1
+    fi
   done
 
   # give atsign user docker permissions

--- a/getdess.sh
+++ b/getdess.sh
@@ -33,7 +33,7 @@ user_info="atsign, secondaries account, atsign.com"
 atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
 
 # Repository files
-repo_url="https://raw.githubusercontent.com/atsign-foundation/dess/trunk"
+repo_url="https://raw.githubusercontent.com/xavierchanth/dess/curl-testing"
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml base/restart.sh"
 dess_scripts="create reshowqr"
 

--- a/getdess.sh
+++ b/getdess.sh
@@ -60,7 +60,32 @@ get_dess_scripts () {
 }
 
 do_install () {
+  pre_install
 
+  sh_c=''
+  if [[ $EUID -ne 0 ]]; then
+    if command_exists sudo; then
+      sh_c='sudo -E sh -c'
+    elif command_exists su; then
+      sh_c='su -c'
+    else
+      echo 'Error: unable to perform root operations';
+      echo 'Please run this script as root to complete installation.';
+      exit 1
+    fi
+  fi
+
+  FUNC=$(declare -f)
+  $sh_c '
+    $FUNC;
+    install_dependencies
+    install_certbot
+    install_docker
+    setup_atsign_user
+    setup_docker
+    test_atsign_user
+    get_dess_scripts
+  ';
 }
 
 do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -134,7 +134,7 @@ mkdir_atsign () {
 }
 
 curl_atsign_file () {
-  curl -fsSL "$repo_url"/"$1" ~atsign/"$1"
+  curl -fsSL "$repo_url"/"$1" -o ~atsign/"$1"
   chown atsign ~atsign/"$1"
 }
 
@@ -211,7 +211,7 @@ get_dess_scripts () {
   # curl create and reshowqr from repo
   # to /usr/local/bin
   for script in $dess_scripts; do
-    curl -fsSL "$repo_url"/"$script".sh /usr/local/bin/dess-"$script"
+    curl -fsSL "$repo_url"/"$script".sh -o /usr/local/bin/dess-"$script"
     chmod +x /usr/local/bin/dess-"$script"
     ln -s /usr/local/bin/dess-"$script" /usr/bin/dess-"$script"
   done

--- a/getdess.sh
+++ b/getdess.sh
@@ -105,7 +105,7 @@ install_dependencies () {
 
 install_certbot () {
   case "$os_release" in
-    centos) echo y | $pkg_man -y install epel-release;;
+    centos|rocky) echo y | $pkg_man -y install epel-release;;
     amzn) echo y | amazon-linux-extras install epel;;
     rhel) echo y | $pkg_man -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$($os_id | awk -F. '{print $1}').noarch.rpm";;
     *);;

--- a/getdess.sh
+++ b/getdess.sh
@@ -140,7 +140,7 @@ install_docker () {
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
       aarch64|arm64) 
         case "$os_release" in
-          amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;;
+          amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel gcc;;
           *) $pkg_man install -y python3 python3-pip;;
         esac;
         pip3 install docker-compose;

--- a/getdess.sh
+++ b/getdess.sh
@@ -12,3 +12,55 @@ set -m
 
 # Container Dependencies
 # fuse squashfuse
+
+
+preinstall () {
+  # get user's release
+  # get package manager
+  # update package repos
+}
+
+install_dependencies () {
+  # openssl, qrencode, curl
+  # if container
+  # install fuse squashfuse
+}
+
+install_certbot () {
+  # install snapd
+  # install snap core
+  # enable and link snap
+  # install certbot
+}
+
+install_docker () {
+  # docker, docker compose
+}
+
+setup_atsign_user () {
+  # add atsign user
+  # link lets-encrypt folder
+  # make ~atsign directories
+  # curl the base files for atsign
+}
+
+setup_docker () {
+  # curl the base/shepherd.yaml file to atsign
+  # give atsign user docker permissions
+  # setup and deploy the swarm as atsign
+}
+
+test_atsign_user () {
+  # check if docker works for atsign user
+}
+
+get_dess_scripts () {
+  # curl create and reshowqr from repo
+  # to /usr/local/bin
+}
+
+do_install () {
+
+}
+
+do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -211,35 +211,8 @@ get_dess_scripts () {
   done
 }
 
-functions="
-  command_exists
-  pre_install
-  install_dependencies
-  install_certbot
-  install_docker
-  mkdir_atsign
-  curl_atsign_file
-  setup_atsign_user
-  setup_docker
-  test_atsign_user
-  get_dess_scripts
-  "
-
-export_functions () {
-  for func in $functions; do
-    export -f "${func?}"
-  done
-}
-
-unset_functions () {
-  for func in $functions; do
-    unset "$func"
-  done
-}
-
 do_install () {
   pre_install
-  export_functions
 
   if [[ $EUID -ne 0 ]]; then
     echo 'Error: unable to perform root operations';
@@ -254,8 +227,6 @@ do_install () {
   setup_docker
   test_atsign_user
   get_dess_scripts
-
-  unset_functions
 }
 
 do_install

--- a/getdess.sh
+++ b/getdess.sh
@@ -92,30 +92,11 @@ install_dependencies () {
 }
 
 install_certbot () {
-  # install snapd
-  if [[ "$os_release" == centos ]]; then
-    $pkg_man -y install epel-release
-  elif [[ "$os_release" == fedora ]]; then
-    $pkg_man -y install kernel-modules
-  fi
-  $pkg_man -y install snapd
-  ln -s /var/lib/snapd/snap /snap
-  # enable and start snapd
-  systemctl enable --now snapd.service
-  systemctl start snapd.service
-  # wait for snapd to startup
-  STATUS=1
-  while [[ $STATUS -ne 0 ]]; do
-    systemctl is-active --quiet snapd.service
-    STATUS=$?
-  done
-  echo Starting snapd service
-  sleep 2
-  # install snap core
-  snap install core
-  snap refresh core
-  # install certbot
-  snap install --classic certbot
+  case "$os_release" in
+    centos) echo y | $pkg_man -y install epel-release;;
+    *);;
+  esac
+  echo y | $pkg_man -y install certbot
 }
 
 install_docker () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -37,6 +37,9 @@ repo_url=""
 atsign_files="base/.env base/docker-swarm.yaml base/setup.sh base/shepherd.yaml"
 dess_scripts="create reshowqr"
 
+# Original user
+original_user=$USER
+
 command_exists () {
   command -v "$@" > /dev/null 2>&1
 }
@@ -176,6 +179,9 @@ setup_docker () {
   # give atsign user docker permissions
   usermod -aG docker atsign
 
+  # give user docker permissions
+  usermod -aG docker "$original_user"
+
   # setup and deploy the swarm as atsign
   docker swarm init
   docker network create -d overlay secondaries
@@ -238,7 +244,7 @@ do_install () {
     repo_url=$repo_url
     atsign_files=$atsign_files
     dess_scripts=$dess_scripts
-    original_user=$USER
+    original_user=$original_user
     $FUNC;
     install_dependencies
     install_certbot

--- a/getdess.sh
+++ b/getdess.sh
@@ -141,9 +141,10 @@ install_docker () {
     case $(uname -m) in
       x86_64|amd64) curl -fsSL "$compose_url/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose;;
       aarch64|arm64) case "$os_release" in
-          amzn) sudo yum install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;
-                sudo pip3 install docker-compose;;
-        esac;;
+          amzn) $pkg_man install -y libffi libffi-devel openssl-devel python3 python3-pip python3-devel;;
+                
+        esac;
+        pip3 install docker-compose;;
     esac
     COMPOSE_RESULT=$?
     echo "$COMPOSE_RESULT"

--- a/getdess.sh
+++ b/getdess.sh
@@ -199,7 +199,7 @@ setup_docker () {
 
 test_atsign_user () {
   # check if docker works for atsign user
-  runuser -l atsign -c /usr/bin/docker run hello-world
+  runuser -l atsign -c '/usr/bin/docker run hello-world'
   RESULT=$?
   if [[ $RESULT -eq 0 ]]; then
     echo "Docker setup correctly for atsign user"

--- a/getdess.sh
+++ b/getdess.sh
@@ -169,7 +169,6 @@ setup_atsign_user () {
   for directory in $atsign_dirs; do
     mkdir_atsign "$directory"
   done
-  tput setaf 2
 
   # curl the base files for atsign
   for file in $atsign_files; do

--- a/getdess.sh
+++ b/getdess.sh
@@ -186,7 +186,7 @@ setup_docker () {
   # setup and deploy the swarm as atsign
   docker swarm init
   docker network create -d overlay secondaries
-  docker stack deploy -c ~atsign/base/shepherd.yaml secondaries
+  docker stack deploy -c /home/atsign/base/shepherd.yaml secondaries
 }
 
 test_atsign_user () {

--- a/getdess.sh
+++ b/getdess.sh
@@ -30,7 +30,7 @@ compose_url="https://github.com/docker/compose/releases/download/1.29/docker-com
 user_info="atsign, secondaries account, atsign.com"
 
 # Atsign directories
-atsign_dirs="~atsign/dess ~atsign/base ~atsign/atsign/var ~atsign/atsign/etc ~atsign/atsign/logs"
+atsign_dirs="/home/atsign/dess /home/atsign/base /home/atsign/atsign/var /home/atsign/atsign/etc /home/atsign/atsign/logs"
 
 # Repository files
 repo_url="https://raw.githubusercontent.com/XavierChanth/dess/curl-testing"
@@ -135,9 +135,9 @@ mkdir_atsign () {
 }
 
 curl_atsign_file () {
-  curl -fsSL "$repo_url"/"$1" -o ~atsign/"$1"
+  curl -fsSL "$repo_url/$1" -o "/home/atsign/$1"
   echo "curling $1"
-  chown atsign ~atsign/"$1"
+  chown atsign "/home/atsign/$1"
 }
 
 setup_atsign_user () {

--- a/reshowqr.sh
+++ b/reshowqr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ $# -eq 0 || $# -gt 1 ]] ; then
-    echo 'Usage reshow.sh <@sign>'
-    echo "Example ./reshowqr.sh @bob"
+    echo 'Usage dess-reshowqr <@sign>'
+    echo "Example dess-reshowqr @bob"
     exit 1 
 fi
 if [[ ! -f ~atsign/dess/$1/.env ]]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. I created a script that can be curled with:  
```
curl -fsSL https://raw.githubusercontent.com/XavierChanth/dess/curl-testing/getdess.sh | bash
```
(The instructions.md file is updated with the correct url for atsign-foundation's trunk branch)  
Progress towards #6, still need a more formal github page to close it.

2. Commands are added to the path:  
Before:  
```
./create.sh
#OR
./reshowqr.sh
```
After:  
```
dess-create
#OR
dess-reshowqr
```

3. Added support for other operating systems
Should support Ubuntu, Debian, Centos7, Centos8, Fedora.

Tested and confirmed:
- Ubuntu 20.04
- Debian 10
- Centos 7

**- How I did it**

- Added a detection function to use the correct installation method based on the distro
- Switched to commands available on all of the distros listed above
- Used fallback functions to support distros with varying commands/flags
- Installing fuse and squashfuse on virtualized distros to make sure snapd installs correctly
- Curl all required files to remove git as a dependency
- Combine install_software.sh and scripts/atsign.sh into one file, getdess.sh
- Wrapped everything in functions to prevent bad installations if the curl command is interrupted

**- How to verify it**

- Run the curl command above to pull it from my fork
- Use dess-create command to spin up a dess instance

**- Description for the changelog**
Debian and CentOS support, and one-line installer with curl.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->