### PR TITLE
fix: docker swarm storage volume path

### DIFF
--- a/base/docker-swarm.yaml
+++ b/base/docker-swarm.yaml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ~/atsign/etc/live/${DOMAIN}:/atsign/certs
       - ~/atsign/etc/archive/${DOMAIN}:/archive/${DOMAIN}
-      - ~/atsign/${ATSIGN}:/atsign/storage
+      - ~/atsign/${ATSIGN}/storage:/atsign/storage
     networks:
       second: {}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #31 

**- What I did**

Fixed the path for the storage volume in docker swarm

**- How I did it**

Appended `/storage` to the appropriate path

**- How to verify it**

Download `getdess.sh`
Edit script and replace 'trunk' in `repo_url` with 'XavierChanth-patch-1'
Run it

**- Description for the changelog**
fix: docker swarm storage volume path
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->