### PR TITLE
fix: volume creation location on Ubuntu 18.04

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -165,7 +165,7 @@ change_sh 'atsign'
 
 echo Starting secondary for "$ATSIGN" at "$FQDN" on port "$PORT" as "$DNAME" on Docker
 
-$sh_c "export TMPDIR=/home/atsign/tmp; /usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null;"
+$sh_c "export HOME=/home/atsign; export TMPDIR=$HOME/tmp; /usr/bin/docker-compose --env-file /home/atsign/dess/$ATSIGN/.env -f /home/atsign/dess/$ATSIGN/docker-swarm.yaml config | tee /home/atsign/dess/$ATSIGN/docker-compose.yaml > /dev/null;"
 COMPOSE_RESULT=$?
 if [[ $COMPOSE_RESULT -gt 0 ]]; then
     error_exit 3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

 - Export `$HOME` explicitly as `/home/atsign` before calling docker compose.

**- How I did it**

 Local changes

**- How to verify it**

Replace dess-create script with create.sh from this branch and test it on the appropriate distros.

**- Description for the changelog**
fix: volume creation location on Ubuntu 18.04
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->